### PR TITLE
Fix DB credential handling for arbitrary passwords + content-sync .env parsing

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -75,10 +75,12 @@ workflow does this).
 
 > **Two separate database passwords.** `DB_PASSWORD` is the `server` superuser
 > (used by the importer); `WEBAPP_PASSWORD` is the read-only `webapp` role the
-> server connects as. Generate **two different** strong values, e.g.:
+> server connects as. Generate **two different** strong values with a **URL-safe
+> charset** (hex) — the importer passes the password inside a JDBC URL, where
+> base64 characters like `+`, `/`, and `=` get mangled:
 >
 > ```bash
-> openssl rand -base64 24   # run twice, once per secret
+> openssl rand -hex 24   # run twice, once per secret
 > ```
 >
 > ⚠️ Both are written into the Postgres data volume the **first** time the `db`

--- a/dist/README.md
+++ b/dist/README.md
@@ -75,12 +75,11 @@ workflow does this).
 
 > **Two separate database passwords.** `DB_PASSWORD` is the `server` superuser
 > (used by the importer); `WEBAPP_PASSWORD` is the read-only `webapp` role the
-> server connects as. Generate **two different** strong values with a **URL-safe
-> charset** (hex) — the importer passes the password inside a JDBC URL, where
-> base64 characters like `+`, `/`, and `=` get mangled:
+> server connects as. Generate **two different** strong values — any charset
+> works, since credentials are passed as connection properties, not in the URL:
 >
 > ```bash
-> openssl rand -hex 24   # run twice, once per secret
+> openssl rand -base64 24   # run twice, once per secret
 > ```
 >
 > ⚠️ Both are written into the Postgres data volume the **first** time the `db`

--- a/dist/compose.yaml
+++ b/dist/compose.yaml
@@ -12,9 +12,13 @@ services:
     environment:
       # The server is read-only against the DB, so it connects as the
       # least-privilege `webapp` role (SELECT only), not the `server` superuser.
-      # The env-var override in application.conf takes precedence over the
-      # Google Secret Manager "secret:" lookup, so no GCP credentials are needed.
-      JDBC_URL: "jdbc:postgresql://db:5432/holybook?user=webapp&password=${WEBAPP_PASSWORD:?set WEBAPP_PASSWORD in .env}"
+      # Credentials are passed separately (not in the URL) so the password may
+      # contain any character. The env-var overrides in application.conf take
+      # precedence over the Google Secret Manager "secret:" lookup, so no GCP
+      # credentials are needed.
+      JDBC_URL: "jdbc:postgresql://db:5432/holybook"
+      JDBC_USER: webapp
+      JDBC_PASSWORD: ${WEBAPP_PASSWORD:?set WEBAPP_PASSWORD in .env}
       GEMINI_API_KEY: ${GEMINI_API_KEY:?set GEMINI_API_KEY in .env}
       JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=60 -Dio.ktor.development=false"
     depends_on:
@@ -63,6 +67,10 @@ services:
     image: ${IMPORT_IMAGE:-ghcr.io/holybook/api-import:latest}
     profiles: ["tools"]
     restart: "no"
+    environment:
+      # The importer reads the `server` superuser password from DB_PASSWORD and
+      # passes it as a connection property, so it may contain any character.
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
     volumes:
       - ./data/content:/content:ro
     depends_on:

--- a/dist/sync-content.sh
+++ b/dist/sync-content.sh
@@ -39,11 +39,15 @@ else
   echo "$(ts) flock not available, running without an overlap lock"
 fi
 
-# Load DB_PASSWORD (and IMPORT_IMAGE) from the deploy .env.
-set -a
-# shellcheck disable=SC1091
-. "$COMPOSE_DIR/.env"
-set +a
+# Read DB_PASSWORD from the deploy .env. Do NOT `source` the file: it is a
+# Compose env file, not a shell script, and the password may contain characters
+# the shell would try to interpret. Extract the literal value instead. (Compose
+# loads .env itself for IMPORT_IMAGE etc. when it runs the importer.)
+DB_PASSWORD=$(grep -E '^DB_PASSWORD=' "$COMPOSE_DIR/.env" | head -n1 | cut -d= -f2-)
+if [ -z "$DB_PASSWORD" ]; then
+  echo "$(ts) DB_PASSWORD not found in $COMPOSE_DIR/.env" >&2
+  exit 1
+fi
 
 if [ ! -d "$DATA_DIR/.git" ]; then
   echo "$(ts) cloning $DATA_REPO"

--- a/dist/sync-content.sh
+++ b/dist/sync-content.sh
@@ -39,16 +39,6 @@ else
   echo "$(ts) flock not available, running without an overlap lock"
 fi
 
-# Read DB_PASSWORD from the deploy .env. Do NOT `source` the file: it is a
-# Compose env file, not a shell script, and the password may contain characters
-# the shell would try to interpret. Extract the literal value instead. (Compose
-# loads .env itself for IMPORT_IMAGE etc. when it runs the importer.)
-DB_PASSWORD=$(grep -E '^DB_PASSWORD=' "$COMPOSE_DIR/.env" | head -n1 | cut -d= -f2-)
-if [ -z "$DB_PASSWORD" ]; then
-  echo "$(ts) DB_PASSWORD not found in $COMPOSE_DIR/.env" >&2
-  exit 1
-fi
-
 if [ ! -d "$DATA_DIR/.git" ]; then
   echo "$(ts) cloning $DATA_REPO"
   git clone --branch "$BRANCH" --single-branch "$DATA_REPO" "$DATA_DIR"
@@ -65,8 +55,11 @@ else
 fi
 
 echo "$(ts) reimporting database from content"
+# The importer reads the password from DB_PASSWORD in its environment (injected
+# by Compose from .env), so no credentials appear here or in the URL.
 docker compose run --rm importer \
-  -jdbc "jdbc:postgresql://db:5432/holybook?user=server&password=${DB_PASSWORD}" \
+  -jdbc "jdbc:postgresql://db:5432/holybook" \
+  -u server \
   -i /content
 
 echo "$(ts) import complete, commit $(git -C "$DATA_DIR" rev-parse HEAD)"

--- a/import/src/main/kotlin/app/holybook/import/DatabaseUtils.kt
+++ b/import/src/main/kotlin/app/holybook/import/DatabaseUtils.kt
@@ -30,23 +30,12 @@ fun resetDatabase() {
   }
 }
 
-fun getJdbcUrl(
-  host: String,
-  port: String,
-  database: String,
-  user: String,
-  usePassword: Boolean,
-): String {
-  val passwordQuery =
-    if (usePassword) {
-      "&password=${readPassword()}"
-    } else {
-      ""
-    }
-  return "jdbc:postgresql://$host:$port/$database?user=$user$passwordQuery"
+fun buildJdbcUrl(host: String, port: String, database: String): String {
+  // Credentials are supplied separately to Database.init, not in the URL.
+  return "jdbc:postgresql://$host:$port/$database"
 }
 
-private fun readPassword(): String {
+fun readPassword(): String {
   val console = System.console()
   if (console == null) {
     print("Password: ")

--- a/import/src/main/kotlin/app/holybook/import/Main.kt
+++ b/import/src/main/kotlin/app/holybook/import/Main.kt
@@ -15,23 +15,40 @@ import org.apache.commons.cli.Options
 
 fun main(args: Array<String>): Unit = runBlocking {
   val options = Options()
-  options.addOption("jdbc", true, "Full custom jdbc url")
+  options.addOption("jdbc", true, "Custom jdbc url (without credentials)")
   options.addOption("h", "host", true, "Database host")
   options.addOption("p", "port", true, "Database port")
   options.addOption("d", "database", true, "Database name")
   options.addOption("u", "user", true, "Database username")
-  options.addOption("pwd", "password", false, "Use password")
+  options.addOption("pw", "password-value", true, "Database password")
+  options.addOption("pwd", "password", false, "Prompt for the database password")
   options.addOption("i", "input", true, "Input directory")
 
   val parser = DefaultParser()
   val cmd = parser.parse(options, args)
 
-  Database.init(cmd.getJdbcUrl())
+  Database.init(cmd.getJdbcUrl(), cmd.getDbUser(), cmd.getDbPassword())
   resetDatabase()
   createDatabase()
 
   cmd.getInputDirectory().listFilesRecursive().forEach { processFile(it) }
 }
+
+fun CommandLine.getDbUser(): String = getOptionValue("u", "server")
+
+/**
+ * Resolves the database password from, in order: the -pw option, the
+ * DB_PASSWORD environment variable, or an interactive prompt (-pwd). Returns
+ * null when none is given (e.g. local trust auth). The password is never placed
+ * in the JDBC URL, so it may contain any character.
+ */
+fun CommandLine.getDbPassword(): String? =
+  when {
+    hasOption("pw") -> getOptionValue("pw")
+    System.getenv("DB_PASSWORD") != null -> System.getenv("DB_PASSWORD")
+    hasOption("pwd") -> readPassword()
+    else -> null
+  }
 
 fun processFile(path: Path) {
   log.info("Importing ${path.toAbsolutePath()}")
@@ -47,11 +64,9 @@ fun CommandLine.getJdbcUrl(): String {
     return getOptionValue("jdbc")
   }
 
-  return getJdbcUrl(
+  return buildJdbcUrl(
     host = getOptionValue("h", "127.0.0.1"),
     port = getOptionValue("p", "5432"),
     database = getOptionValue("d", "holybook"),
-    user = getOptionValue("u", "server"),
-    usePassword = hasOption("pwd"),
   )
 }

--- a/lib/src/main/kotlin/app/holybook/lib/db/Database.kt
+++ b/lib/src/main/kotlin/app/holybook/lib/db/Database.kt
@@ -11,8 +11,18 @@ object Database {
   private val dataSource = HikariDataSource()
   private val log: Logger = LoggerFactory.getLogger("db")
 
-  fun init(jdbcUrl: String) {
+  /**
+   * Configures the connection pool.
+   *
+   * Credentials are passed as connection properties rather than embedded in the
+   * JDBC URL, so passwords may contain any character (URL query strings mangle
+   * '+', '/', '=', '&', etc.). [username] and [password] are optional for URLs
+   * that carry no credentials (e.g. SQLite).
+   */
+  fun init(jdbcUrl: String, username: String? = null, password: String? = null) {
     dataSource.jdbcUrl = jdbcUrl
+    username?.let { dataSource.username = it }
+    password?.let { dataSource.password = it }
   }
 
   fun <R> transaction(body: Connection.() -> R): R {

--- a/server/src/main/kotlin/app/holybook/api/Application.kt
+++ b/server/src/main/kotlin/app/holybook/api/Application.kt
@@ -1,5 +1,7 @@
 package app.holybook.api
 
+import app.holybook.api.config.ApplicationConfigExt.getDbPassword
+import app.holybook.api.config.ApplicationConfigExt.getDbUser
 import app.holybook.api.config.ApplicationConfigExt.getJdbcUrl
 import app.holybook.api.plugins.configureRouting
 import app.holybook.lib.db.Database
@@ -17,7 +19,11 @@ import org.slf4j.event.*
 fun main(args: Array<String>) = EngineMain.main(args)
 
 fun Application.module() {
-  Database.init(environment.config.getJdbcUrl())
+  Database.init(
+    environment.config.getJdbcUrl(),
+    environment.config.getDbUser(),
+    environment.config.getDbPassword(),
+  )
 
   val isDevelopment = developmentMode
 

--- a/server/src/main/kotlin/app/holybook/api/config/ApplicationConfigExt.kt
+++ b/server/src/main/kotlin/app/holybook/api/config/ApplicationConfigExt.kt
@@ -20,6 +20,14 @@ object ApplicationConfigExt {
     return getPropertyFromSecret("storage.jdbcUrl")
   }
 
+  fun ApplicationConfig.getDbUser(): String {
+    return getPropertyFromSecret("storage.user")
+  }
+
+  fun ApplicationConfig.getDbPassword(): String {
+    return getPropertyFromSecret("storage.password")
+  }
+
   fun ApplicationConfig.getGeminiApiKey(): String {
     return getPropertyFromSecret("ai.geminiApiKey")
   }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -10,8 +10,12 @@ ktor {
 }
 storage {
     driverClassName = "org.postgresql.Driver"
-    jdbcUrl = "jdbc:postgresql://127.0.0.1:5432/holybook?user=server"
+    jdbcUrl = "jdbc:postgresql://127.0.0.1:5432/holybook"
     jdbcUrl = ${?JDBC_URL}
+    user = "server"
+    user = ${?JDBC_USER}
+    password = ""
+    password = ${?JDBC_PASSWORD}
 }
 ai {
     geminiApiKey = "secret:gemini-api-key"


### PR DESCRIPTION
Follow-up fixes to the deployment merged in #2. The first deploy surfaced two bugs that block the content import; both are fixed here.

## Bugs fixed

**1. Passwords with URL-special characters fail (`7ae4797`)**
Credentials were embedded in the JDBC URL query string, so passwords containing `+`, `/`, `=`, `&` (e.g. anything from `openssl rand -base64`) were mangled by the driver's URL parsing → `password authentication failed`. Now credentials are passed to HikariCP as connection properties, where the driver takes them literally.
- `Database.init(url, username?, password?)` sets them on the pool; the URL carries no credentials (SQLite `index` caller unaffected).
- Importer resolves the password from `-pw`, the `DB_PASSWORD` env var, or the `-pwd` prompt.
- Server reads `storage.user` / `storage.password` (`JDBC_USER` / `JDBC_PASSWORD`).
- Compose: server uses `JDBC_USER`/`JDBC_PASSWORD`; importer reads `DB_PASSWORD` from its env.

Verified end-to-end with passwords containing `+`, `/`, `=`, and `&`: both the importer (superuser) and the server (read-only webapp role) connect and serve.

**2. `sync-content.sh` breaks on the rendered `.env` (`b6bd247`)**
The script `source`d the Compose `.env` to read `DB_PASSWORD`, but a Compose env file isn't a shell script — special characters in the password caused `fg: no job control`. The script no longer sources `.env` at all; Compose injects `DB_PASSWORD` into the importer container directly.

## Reviewer note
With this merged and deployed, the **existing** `DB_PASSWORD` secret works as-is — no password change, ALTER, or volume recreate needed. Suggest **squash-merge** to collapse the interim doc commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)