### PR TITLE
Make content sync self-healing via applied-commit tracking in the DB

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -95,14 +95,18 @@ repo by [`sync-content.sh`](sync-content.sh), which is deployed to
 `~/holybook/sync-content.sh`:
 
 1. It clones/pulls `holybook/data` into `~/holybook/data`.
-2. If `main` moved since the last run, it reimports the whole dataset from
+2. It compares the repo HEAD against the commit actually imported into the
+   database — the importer records this in a small `sync_state` table **after** a
+   successful import. If they differ, it reimports the whole dataset from
    `data/content/` via the `importer` container (`docker compose run --rm
    importer`). The importer drops and recreates the schema, so the database ends
    up an exact mirror of the repo HEAD — added books appear, changed books are
-   replaced, removed books vanish. The local clone's HEAD is the record of which
-   commit is in the DB.
+   replaced, removed books vanish.
 
-It is a no-op when there are no new commits, so it is safe to run often.
+Because the marker is the *imported* commit (not the local clone's HEAD), a run
+that fetched but failed to import is not mistaken for "in sync" — the import is
+retried on the next run. It is a no-op when there are no new commits, so it is
+safe to run often.
 
 ### Run it manually
 

--- a/dist/sync-content.sh
+++ b/dist/sync-content.sh
@@ -44,22 +44,33 @@ if [ ! -d "$DATA_DIR/.git" ]; then
   git clone --branch "$BRANCH" --single-branch "$DATA_REPO" "$DATA_DIR"
 else
   git -C "$DATA_DIR" fetch --quiet origin "$BRANCH"
-  local_sha=$(git -C "$DATA_DIR" rev-parse HEAD)
-  remote_sha=$(git -C "$DATA_DIR" rev-parse "origin/$BRANCH")
-  if [ "$local_sha" = "$remote_sha" ]; then
-    echo "$(ts) no content changes ($local_sha), nothing to do"
-    exit 0
-  fi
-  echo "$(ts) updating content $local_sha -> $remote_sha"
-  git -C "$DATA_DIR" reset --hard "origin/$BRANCH"
+fi
+remote_sha=$(git -C "$DATA_DIR" rev-parse "origin/$BRANCH")
+
+# Compare against the commit actually imported into the database (recorded by
+# the importer), not the local clone's HEAD. This way a previous run that
+# cloned/fetched but failed to import does not look "in sync" — the import is
+# retried until it succeeds. Empty when the table or row does not exist yet.
+applied_sha=$(docker compose exec -T db \
+  psql -U server -d holybook -tAc \
+  "SELECT value FROM sync_state WHERE key = 'applied_commit'" 2>/dev/null |
+  tr -d '[:space:]' || true)
+
+if [ "$remote_sha" = "$applied_sha" ]; then
+  echo "$(ts) database already at $remote_sha, nothing to do"
+  exit 0
 fi
 
-echo "$(ts) reimporting database from content"
+echo "$(ts) importing ${applied_sha:-<none>} -> $remote_sha"
+git -C "$DATA_DIR" reset --hard --quiet "origin/$BRANCH"
+
 # The importer reads the password from DB_PASSWORD in its environment (injected
-# by Compose from .env), so no credentials appear here or in the URL.
+# by Compose from .env), so no credentials appear here or in the URL. It records
+# the commit as applied only after the import completes successfully.
 docker compose run --rm importer \
   -jdbc "jdbc:postgresql://db:5432/holybook" \
   -u server \
+  --commit "$remote_sha" \
   -i /content
 
-echo "$(ts) import complete, commit $(git -C "$DATA_DIR" rev-parse HEAD)"
+echo "$(ts) import complete, database now at $remote_sha"

--- a/import/src/main/kotlin/app/holybook/import/DatabaseUtils.kt
+++ b/import/src/main/kotlin/app/holybook/import/DatabaseUtils.kt
@@ -30,6 +30,37 @@ fun resetDatabase() {
   }
 }
 
+/**
+ * Tracks which content commit is currently imported. Lives outside the content
+ * tables (it is not dropped by [resetDatabase]) so the sync job can compare the
+ * repository HEAD against what was actually imported, and is only advanced after
+ * a successful import — making the sync self-healing if an import fails midway.
+ */
+fun createSyncStateTable() {
+  transaction {
+    createStatement()
+      .executeUpdate(
+        "CREATE TABLE IF NOT EXISTS sync_state (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+      )
+  }
+}
+
+fun recordAppliedCommit(commit: String) {
+  log.info("Recording applied commit $commit")
+  transaction {
+    val statement =
+      prepareStatement(
+        """
+        INSERT INTO sync_state(key, value) VALUES ('applied_commit', ?)
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+        """
+          .trimIndent()
+      )
+    statement.setString(1, commit)
+    statement.executeUpdate()
+  }
+}
+
 fun buildJdbcUrl(host: String, port: String, database: String): String {
   // Credentials are supplied separately to Database.init, not in the URL.
   return "jdbc:postgresql://$host:$port/$database"

--- a/import/src/main/kotlin/app/holybook/import/Main.kt
+++ b/import/src/main/kotlin/app/holybook/import/Main.kt
@@ -23,6 +23,7 @@ fun main(args: Array<String>): Unit = runBlocking {
   options.addOption("pw", "password-value", true, "Database password")
   options.addOption("pwd", "password", false, "Prompt for the database password")
   options.addOption("i", "input", true, "Input directory")
+  options.addOption("c", "commit", true, "Content commit to record as applied after import")
 
   val parser = DefaultParser()
   val cmd = parser.parse(options, args)
@@ -30,8 +31,14 @@ fun main(args: Array<String>): Unit = runBlocking {
   Database.init(cmd.getJdbcUrl(), cmd.getDbUser(), cmd.getDbPassword())
   resetDatabase()
   createDatabase()
+  createSyncStateTable()
 
   cmd.getInputDirectory().listFilesRecursive().forEach { processFile(it) }
+
+  // Only mark the commit as applied once the whole import has completed, so a
+  // failure partway through leaves the recorded commit unchanged and the next
+  // sync run retries.
+  cmd.getOptionValue("c")?.let { recordAppliedCommit(it) }
 }
 
 fun CommandLine.getDbUser(): String = getOptionValue("u", "server")


### PR DESCRIPTION
Fixes the design gap where a failed import left the system thinking it was in sync.

## Problem
`sync-content.sh` used the local clone's HEAD as its "what's imported" marker. A run that fetched/cloned but then failed to import (e.g. the auth bug from the first deploy) left the clone advanced, so the next run reported "no content changes" and never retried — leaving the database empty.

## Fix
Track the imported commit **in the database**, written only after a successful import:
- The importer creates a small `sync_state` table and records the commit passed via `--commit <sha>` after the import loop completes.
- `sync-content.sh` reads that recorded commit (via `psql`) and compares it against the repo HEAD, instead of the clone's HEAD. A failed import leaves the marker unchanged, so the next run retries until it succeeds.
- The query tolerates the table not existing yet (fresh DB).

## Verified end-to-end
- Fresh DB → imports and records the commit (`sync_state.applied_commit`, 527 books).
- Unchanged repo → no-op ("database already at <sha>").
- **Stale marker (simulating a failed prior import) → reimports** instead of skipping. This is exactly the situation that required a manual force-import before.

## Note for reviewer
This branches off `droplet-deployment` (PR #3), so until #3 is merged this PR's diff also shows #3's commits. **Merge #3 first**, then this PR shows only the commit-tracking change. No new secrets or deploy-config changes; once deployed, `sync-content.sh` self-heals with no manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)